### PR TITLE
Fix key error

### DIFF
--- a/media_sync.py
+++ b/media_sync.py
@@ -96,7 +96,7 @@ def mc_pull(mc):
     local_version = mp.metadata["version"]
 
     try:
-        project_info = mc.project_info(project_path)
+        project_info = mc.project_info(project_path, since=local_version)
         projects = mc.get_projects_by_names([project_path])
         server_version = projects[project_path]["version"]
     except ClientError as e:

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -198,9 +198,15 @@ def test_pull_and_sync(mc):
     # initial run
     main()
 
-    # let's update project on server
+    # let's update project on server - create new .png file and modify reference .gpkg file
     project_dir = os.path.join(TMP_DIR, project_name + '_create')
     shutil.copyfile(os.path.join(project_dir, 'img1.png'), os.path.join(project_dir, 'img_new.png'))
+    gpkg_conn = sqlite3.connect(os.path.join(project_dir, 'survey.gpkg'))
+    gpkg_conn.enable_load_extension(True)
+    gpkg_cur = gpkg_conn.cursor()
+    gpkg_cur.execute('SELECT load_extension("mod_spatialite")')
+    gpkg_cur.execute("update notes set photo = 'img_new.png' where name = 'test'")
+    gpkg_conn.commit()
     mc.push_project(project_dir)
     project_info = mc.project_info(full_project_name)
     assert project_info["version"] == "v2"


### PR DESCRIPTION
PR addresses the issue with media sync trying to pull changes from mergin server when reference .gpkg file was modified. The issue was caused by incorrect use of py-client API.
